### PR TITLE
Fix compilation for SSReflect 1.11 + warnings

### DIFF
--- a/Core/idynamic.v
+++ b/Core/idynamic.v
@@ -52,7 +52,7 @@ Definition ijmeq A B (v1 : sort A) (v2 : sort B) :=
 Lemma ijmeq_refl A (v : sort A) : ijmeq v v.
 Proof. by move=>pf; rewrite ieqc. Qed.
 
-Hint Resolve ijmeq_refl.
+Hint Resolve ijmeq_refl : core.
 
 Lemma ijmE A (v1 v2 : sort A) : ijmeq v1 v2 <-> v1 = v2.
 Proof. by split=>[|->]; first by move/(_ (erefl _)). Qed.
@@ -65,7 +65,4 @@ End IndexedDynamic.
 
 Prenex Implicits idyn_tp idyn_val idyn_injT idyn_inj.
 Arguments icoerce [I] sort [A B].
-Hint Resolve ijmeq_refl.
-
-
-
+Hint Resolve ijmeq_refl : core.

--- a/Core/pperm.v
+++ b/Core/pperm.v
@@ -1,4 +1,4 @@
-Require Import ssreflect ssrfun. 
+Require Import ssreflect ssrfun.
 From mathcomp.ssreflect Require Import ssrbool ssrnat seq eqtype path.
 From HTT Require Import pred.
 Set Implicit Arguments.
@@ -12,284 +12,187 @@ Import Prenex Implicits.
 Section Permutations.
 Variable A : Type.
 
-Lemma in_split (x : A) (s : seq A) :
-        x \In s -> exists s1, exists s2, s = s1 ++ x :: s2.
+Inductive perm : seq A -> seq A -> Prop :=
+| permutation_nil : perm [::] [::]
+| permutation_skip x s1 s2 of perm s1 s2 : perm (x :: s1) (x :: s2)
+| permutation_swap x y s1 s2 of perm s1 s2 : perm [:: x, y & s1] [:: y, x & s2]
+| permutation_trans t s1 s2 of perm s1 t & perm t s2 : perm s1 s2.
+
+Lemma pperm_refl (s : seq A) : perm s s.
+Proof. by elim: s=>*; [apply: permutation_nil | apply: permutation_skip]. Qed.
+
+Hint Resolve pperm_refl : core.
+
+Lemma pperm_nil (s : seq A) : perm [::] s <-> s = [::].
 Proof.
-elim:s=>[|y s IH] //=; rewrite InE.
-case=>[<-|]; first by exists [::]; exists s.
-by case/IH=>s1 [s2] ->; exists (y :: s1); exists s2.
+split; last by move=>->; apply: permutation_nil.
+move E: {1}[::]=>l H; move: H {E}(esym E).
+by elim=>//??? _ IH1 _ IH2 /IH1/IH2.
 Qed.
 
-Inductive perm (s1 s2 : seq A) : Prop :=
-| permutation_nil of s1 = [::] & s2 = [::]
-| permutation_skip x t1 t2 of s1 = x :: t1 & s2 = x :: t2 & perm t1 t2
-| permutation_swap x y t of s1 = x :: y :: t & s2 = y :: x :: t
-| permutation_trans t of perm s1 t & perm t s2.
-
-Lemma perm_nil (s : seq A) : perm [::] s <-> s = [::].
+Lemma pperm_sym s1 s2 : perm s1 s2 <-> perm s2 s1.
 Proof.
-split=>[H|]; last by move=>->; apply: permutation_nil.
-move: {1 2}[::] s H (erefl (Nil A)).
-apply: perm_ind=>[|s1 s2 x t1 t2 ->|s1 s2 x y t ->|s1 s2 t _ IH1 _ IH2] //.
-by move/IH1; move/IH2.
+suff {s1 s2} L : forall s1 s2, perm s1 s2 -> perm s2 s1 by split; apply: L.
+apply: perm_ind=>[|||??? _ H1 _ H2] *;
+by [apply: permutation_nil | apply: permutation_skip |
+    apply: permutation_swap | apply: permutation_trans H2 H1].
 Qed.
 
-Lemma perm_refl (s : seq A) : perm s s.
-Proof.
-elim:s=>[|e s IH]; first by apply: permutation_nil.
-by apply: (permutation_skip (x:=e)) IH.
-Qed.
-
-Hint Resolve perm_refl.
-
-Lemma perm_sym s1 s2 : perm s1 s2 <-> perm s2 s1.
-Proof.
-suff L: forall s1 s2, perm s1 s2 -> perm s2 s1 by split; apply: L.
-apply: perm_ind=>s1' s2'.
-- by move=>->->; apply: permutation_nil.
-- by move=>x t1 t2 -> -> H1; apply: permutation_skip.
-- by move=>x y t -> ->; apply: permutation_swap.
-by move=>t _ H1 _ H2; apply: permutation_trans H2 H1.
-Qed.
-
-Lemma perm_trans s2 s1 s3 : perm s1 s2 -> perm s2 s3 -> perm s1 s3.
+Lemma pperm_trans s2 s1 s3 : perm s1 s2 -> perm s2 s3 -> perm s1 s3.
 Proof. by apply: permutation_trans. Qed.
 
-Lemma perm_in s1 s2 x : perm s1 s2 -> x \In s1 -> x \In s2.
-Proof.
-move: s1 s2; apply: perm_ind=>s1 s2.
-- by move=>->->.
-- move=>y t1 t2 -> -> H; rewrite !InE; tauto.
-- by move=>y z t -> ->; rewrite !InE; tauto.
-by move=>t _ IH1 _ IH2; move/IH1; move/IH2.
-Qed.
+Lemma pperm_in s1 s2 x : perm s1 s2 -> x \In s1 -> x \In s2.
+Proof. elim=>//??? =>[|?|_ I1 _ I2 /I1/I2]; rewrite ?InE; tauto. Qed.
 
-Lemma perm_cat2lL s s1 s2 : perm s1 s2 -> perm (s ++ s1) (s ++ s2).
-Proof. by elim:s=>[|e s IH] //=; move/IH; apply: permutation_skip. Qed.
-
-Lemma perm_cat2rL s s1 s2 : perm s1 s2 -> perm (s1 ++ s) (s2 ++ s).
+Lemma pperm_catC s1 s2 : perm (s1 ++ s2) (s2 ++ s1).
 Proof.
-move=>H; move: s1 s2 H s; apply: perm_ind=>s1 s2.
-- by move=>->->.
-- by move=>x t1 t2 -> -> H IH s /=; apply: permutation_skip.
-- by move=>x y t -> -> s /=; apply: permutation_swap.
-by move=>t H1 IH1 H2 IH2 s; apply: permutation_trans (IH2 s).
-Qed.
-
-Lemma perm_catL s1 t1 s2 t2 :
-        perm s1 s2 -> perm t1 t2 -> perm (s1 ++ t1) (s2 ++ t2).
-Proof.
-move=>H; move: s1 s2 H t1 t2; apply: perm_ind=>s1 s2.
-- by move=>->->.
-- move=>x t1 t2 -> -> H IH r1 r2.
-  by move/IH; apply: permutation_skip.
-- move=>x y t -> -> t1 t2 H.
-  by apply: (permutation_trans (t:=[:: x, y & t] ++ t2));
-     [apply: perm_cat2lL | simpl; apply: permutation_swap].
-move=>t H1 IH1 H2 IH2 t1 t2 H.
-by apply: permutation_trans (IH2 _ _ H); apply: IH1.
-Qed.
-
-Lemma perm_cat_consL s1 t1 s2 t2 x :
-        perm s1 s2 -> perm t1 t2 -> perm (s1 ++ x :: t1) (s2 ++ x :: t2).
-Proof.
-by move=>H1 H2; apply: perm_catL H1 _; apply: permutation_skip H2.
-Qed.
-
-Lemma perm_catC s1 s2 : perm (s1 ++ s2) (s2 ++ s1).
-Proof.
-elim:s1 s2=>[|x s1 IH1] s2 /=; first by rewrite cats0.
-apply: (@perm_trans (x::s2++s1)); first by apply: permutation_skip (IH1 s2).
+elim: s1 s2=>[|x s1 IH1] s2 /=; first by rewrite cats0.
+apply: (@pperm_trans (x::s2++s1)); first by apply: permutation_skip.
 elim: s2=>[|y s2 IH2] //=.
-apply: (@perm_trans (y::x::s2++s1)); first by apply: permutation_swap.
-by apply: permutation_skip IH2.
+apply: (@pperm_trans (y::x::s2++s1)); first by apply: permutation_swap.
+by apply: permutation_skip.
 Qed.
 
-Hint Resolve perm_catC.
+Hint Resolve pperm_catC : core.
 
-Lemma perm_cons_catCA s1 s2 x : perm (x :: s1 ++ s2) (s1 ++ x :: s2).
+Lemma pperm_cat2lL s s1 s2 : perm s1 s2 -> perm (s ++ s1) (s ++ s2).
+Proof. by elim: s=>[//|e s IH /IH]; apply: permutation_skip. Qed.
+
+Lemma pperm_cat2rL s s1 s2 : perm s1 s2 -> perm (s1 ++ s) (s2 ++ s).
 Proof.
-rewrite -cat_rcons -cats1 -cat_cons -cat1s.
-by apply: perm_cat2rL; apply: perm_catC.
+move=>?.
+apply: (@pperm_trans (s ++ s1)); first by apply: pperm_catC.
+apply: (@pperm_trans (s ++ s2)); last by apply: pperm_catC.
+by apply: pperm_cat2lL.
 Qed.
 
-Lemma perm_cons_catAC s1 s2 x : perm (s1 ++ x :: s2) (x :: s1 ++ s2).
-Proof. by apply/perm_sym; apply: perm_cons_catCA. Qed.
+Lemma pperm_catL s1 t1 s2 t2 :
+        perm s1 s2 -> perm t1 t2 -> perm (s1 ++ t1) (s2 ++ t2).
+Proof. by move/(pperm_cat2rL t1)=>H1/(pperm_cat2lL s2); apply: pperm_trans. Qed.
 
-Hint Resolve perm_cons_catCA perm_cons_catAC.
+Lemma pperm_cat_consL s1 t1 s2 t2 x :
+        perm s1 s2 -> perm t1 t2 -> perm (s1 ++ x :: t1) (s2 ++ x :: t2).
+Proof. by move=>*; apply: pperm_catL=>//; apply: permutation_skip. Qed.
 
-Lemma perm_cons_cat_consL s1 s2 s x :
+Lemma pperm_cons_catCA s1 s2 x : perm (x :: s1 ++ s2) (s1 ++ x :: s2).
+Proof.
+rewrite -cat1s -(cat1s _ s2) !catA.
+by apply/pperm_cat2rL/pperm_catC.
+Qed.
+
+Lemma pperm_cons_catAC s1 s2 x : perm (s1 ++ x :: s2) (x :: s1 ++ s2).
+Proof. by apply/pperm_sym/pperm_cons_catCA. Qed.
+
+Hint Resolve pperm_cons_catCA pperm_cons_catAC : core.
+
+Lemma pperm_cons_cat_consL s1 s2 s x :
         perm s (s1 ++ s2) -> perm (x :: s) (s1 ++ x :: s2).
 Proof.
-case: s1=>[|a s1] /= H; first by apply: permutation_skip.
-apply: (@perm_trans (x::a::s1++s2)); first by apply: permutation_skip.
-apply: (@perm_trans (a::x::s1++s2)); first by apply: permutation_swap.
-by apply: permutation_skip=>//; apply: perm_catCA.
+move=>?.
+apply: (@pperm_trans (x :: (s1 ++ s2))); first by apply: permutation_skip.
+by apply: pperm_cons_catCA.
 Qed.
 
-(* a somewhat generalized induction principle *)
-Lemma perm_ind2 (P : seq A -> seq A -> Prop) :
-        P [::] [::] ->
-        (forall x s1 s2, perm s1 s2 -> P s1 s2 ->
-           P (x :: s1) (x :: s2)) ->
-        (forall x y s1 s2, perm s1 s2 -> P s1 s2 ->
-           P (y :: x :: s1) (x :: y :: s2)) ->
-        (forall s2 s1 s3, perm s1 s2 -> P s1 s2 ->
-           perm s2 s3 -> P s2 s3 -> P s1 s3) ->
-        forall s1 s2, perm s1 s2 -> P s1 s2.
-Proof.
-move=>H1 H2 H3 H4; apply: perm_ind=>s1 s2; last 1 first.
-- by move=>t; apply: H4.
-- by move=>->->.
-- by move=>x t1 t2 -> ->; apply: H2.
-move=>x y t -> ->.
-have R : forall t, P t t by elim=>[|e t1 IH] //; apply:  H2.
-apply: (H4 (y :: x :: t))=>//; last by apply: H3.
-by apply: permutation_swap.
-Qed.
+Lemma pperm_size l1 l2: perm l1 l2 -> size l1 = size l2.
+Proof. by elim=>//=???? =>[|?|]->. Qed.
 
-Lemma perm_size l1 l2: perm l1 l2 -> size l1 = size l2.
-Proof.
-move: l1 l2; apply: perm_ind=>s1 s2=>[|x t1 t2|x y t|t]; first by move=>->->.
-- by move=>->->{s1 s2} _ /=->.
-- by move=>->->{s1 s2}/=.
-- by move=>_->_->.
-Qed.
-
-(* Now the hard part; the opposite implications *)
-Lemma perm_cat_consR s1 t1 s2 t2 x :
+Lemma pperm_cat_consR s1 s2 t1 t2 x :
         perm (s1 ++ x :: t1) (s2 ++ x :: t2) -> perm (s1 ++ t1) (s2 ++ t2).
 Proof.
 move: s1 t1 s2 t2 x.
 suff H:
   forall r1 r2, perm r1 r2 -> forall x s1 t1 s2 t2,
     r1 = s1 ++ x :: t1 -> r2 = s2 ++ x :: t2 -> perm (s1 ++ t1) (s2 ++ t2).
-- by move=>s1 t1 s2 t2 x; move/H; apply.
-apply: perm_ind2; last 1 first.
+- by move=>s1 t1 s2 t2 x /H; apply.
+apply: perm_ind; last 1 first.
 - move=>s2 s1 s3 H1 IH1 H2 IH2 x r1 t1 r2 t2 E1 E2.
-  case: (@in_split x s2).
-  - apply: perm_in H1 _; rewrite E1; apply: (@perm_in (x::r1++t1))=>//.
-  by rewrite InE; left.
-  move=>s4 [s5] E; apply: (@perm_trans (s4++s5)); first by apply: IH1 E1 E.
+  case: (@In_split _ x s2).
+  - by apply: pperm_in H1 _; rewrite E1 Mem_cat; right; left.
+  move=>s4 [s5] E; apply: (@pperm_trans (s4++s5)); first by apply: IH1 E1 E.
   by apply: IH2 E E2.
 - by move=>x [].
-- move=>x t1 t2 H IH y s1 s2 p1 p2 E1 E2.
-  case: s1 E1=>[|b s1] /=; case: p1 E2=>[|c p1] /= E1 E2.
-  - by case: E1 E2=><- <- [<-].
-  - apply: (@perm_trans (p1 ++ c :: p2))=>//.
-    by case: E1 H=><- ->; case: E2=><- ->.
-  - case: E1 E2 H=><- <- [<-] ->; apply: (@perm_trans (s1 ++ x:: s2)).
-    by apply: perm_cons_cat_consL.
-  case: E1 E2 H IH=><- -> [<-] -> H IH.
-  by apply: permutation_skip=>//; apply: IH.
-move=>x y p1 p2 H IH z s1 t1 s2 t2 E1 E2.
-case: s1 E1 H IH=>[|b s1]; case: s2 E2=>[|c s2]=>/=.
-- by case=><- <- [<-] <- H IH; apply: permutation_skip.
-- case=><-; case: s2=>[|b s2] /=.
-  - by case=><- <-; case=><- H IH; apply: permutation_skip H.
-  case=><- -> [<-] <- H IH.
-  by apply: permutation_skip=>//; apply: perm_trans H _.
-- case=><- <- [<-]; case: s1=>[|a s1] /=.
-  - by case=><- H IH; apply: permutation_skip.
-  by case=><- -> H IH; apply: permutation_skip=>//; apply: perm_trans H.
-case=><-; case: s2=>[|a s2] /=; case: s1=>[|d s1] /=.
-- by case=><- <- [<-] <- <- H IH; apply: permutation_skip.
-- case=><- <- [<-] <- -> H IH.
-  apply: (@perm_trans (x::y::s1 ++ t1)); first by apply: permutation_swap.
-  by apply: permutation_skip=>//; apply: perm_trans H.
-- case=><- -> [<-] <- <- H IH.
-  apply: (@perm_trans (y::x::s2++t2)); last by apply: permutation_swap.
-  by apply: permutation_skip=>//; apply: perm_trans H _.
-case=><- -> [<-] <- -> H IH.
-apply: (@perm_trans (x::y::s1++t1)); first by apply: permutation_swap.
-by apply: permutation_skip=>//; apply: permutation_skip=>//; apply: IH.
+- move=>x t1 t2 H IH y [|b s1] s2 [|c p1] p2 /= [E1 E2] [E3 E4]; subst x;
+    rewrite ?E1 ?E2 ?E3 ?E4 in H * =>//.
+  - by subst y; apply: pperm_trans H _.
+  - by apply: pperm_trans H.
+  by apply: permutation_skip=>//; apply: IH E2 E4.
+move=>x y p1 p2 H IH z [|b s1] t1 [|c s2] t2 /= [E1 E2] [E3 E4]; subst x y;
+  rewrite -?E2 -?E4 in H IH * =>//.
+- by apply: permutation_skip.
+- case: s2 E4=>/=[|a s2][<-]=>[|E4]; apply: permutation_skip=>//.
+  by subst p2; apply: pperm_trans H _; apply pperm_cons_catAC.
+- case: s1 E2=>/=[|a s1][<-]=>[|E2]; apply: permutation_skip=>//.
+  by subst p1; apply: pperm_trans H; apply pperm_cons_catCA.
+case: s1 E2=>/=[|a s1][->]=>E2; case: s2 E4=>/=[|d s2][->]=>E4;
+  rewrite ?E2 ?E4 in H IH *.
+- by apply: permutation_skip.
+- apply: (@pperm_trans [:: d, z & s2 ++ t2]); last by apply: permutation_swap.
+  by apply: permutation_skip=>//; apply/(pperm_trans H _ )/pperm_cons_catAC.
+- apply: (@pperm_trans [:: a, z & s1 ++ t1]); first by apply: permutation_swap.
+  by apply: permutation_skip=>//; apply/pperm_trans/H/pperm_cons_catCA.
+by apply: permutation_swap; apply: IH.
 Qed.
 
-Lemma perm_cons x s1 s2 : perm (x :: s1) (x :: s2) <-> perm s1 s2.
+Lemma pperm_cons x s1 s2 : perm (x :: s1) (x :: s2) <-> perm s1 s2.
 Proof.
-split; last by apply: permutation_skip.
-by move/(@perm_cat_consR [::] s1 [::] s2 x).
+by split; [apply/(@pperm_cat_consR [::] [::]) | apply: permutation_skip].
 Qed.
 
-Lemma perm_cons_cat_cons x s1 s2 s :
+Lemma pperm_cat2l s s1 s2: perm (s ++ s1) (s ++ s2) <-> perm s1 s2.
+Proof. by split; [elim: s=>// ??? /pperm_cons | apply: pperm_cat2lL]. Qed.
+
+Lemma pperm_cat2r s s1 s2 : perm (s1 ++ s) (s2 ++ s) <-> perm s1 s2.
+Proof.
+split; last by apply: pperm_cat2rL.
+by elim: s=>[|??? /pperm_cat_consR]; rewrite ?cats0.
+Qed.
+
+Lemma pperm_catAC s1 s2 s3 : perm ((s1 ++ s2) ++ s3) ((s1 ++ s3) ++ s2).
+Proof. by move=>*; rewrite -!catA pperm_cat2l. Qed.
+
+Lemma pperm_catCA s1 s2 s3 : perm (s1 ++ s2 ++ s3) (s2 ++ s1 ++ s3).
+Proof. by move=>*; rewrite !catA pperm_cat2r. Qed.
+
+Lemma pperm_cons_cat_cons x s1 s2 s :
         perm (x :: s) (s1 ++ x :: s2) <-> perm s (s1 ++ s2).
 Proof.
-split=>[|H]; first by by move/(@perm_cat_consR [::] s s1 s2 x).
-by apply: (@perm_trans (x :: s1++s2))=>//; apply: permutation_skip.
+by split; [apply: (@pperm_cat_consR [::]) | apply: pperm_cons_cat_consL].
 Qed.
 
-Lemma perm_cat_cons x s1 s2 t1 t2 :
+Lemma pperm_cat_cons x s1 s2 t1 t2 :
         perm (s1 ++ x :: t1) (s2 ++ x :: t2) <-> perm (s1 ++ t1) (s2 ++ t2).
 Proof.
-split=>[|H]; first by apply: perm_cat_consR.
-apply: (@perm_trans (x::s1++t1))=>//; apply: (@perm_trans (x::s2++t2))=>//.
-by apply/perm_cons.
+split=>[|H]; first by apply: pperm_cat_consR.
+apply: (@pperm_trans (x::s1++t1))=>//; apply: (@pperm_trans (x::s2++t2))=>//.
+by apply/pperm_cons.
 Qed.
-
-Lemma perm_cat2l s1 s2 s3: perm (s1 ++ s2) (s1 ++ s3) <-> perm s2 s3.
-Proof.
-split; last by apply: perm_cat2lL.
-elim: s1 s2 s3=>[|x s1 IH] s2 s3 //= H.
-by apply: IH; move/perm_cons: H.
-Qed.
-
-Lemma perm_cat2r s1 s2 s3 : perm (s2 ++ s1) (s3 ++ s1) <-> perm s2 s3.
-Proof.
-split; last by apply: perm_cat2rL.
-elim: s1 s2 s3=>[|x s1 IH] s2 s3 /=; first by rewrite !cats0.
-by move=>H; apply: IH; apply: perm_cat_consR H.
-Qed.
-
-Lemma perm_catAC s1 s2 s3 : perm ((s1 ++ s2) ++ s3) ((s1 ++ s3) ++ s2).
-Proof. by move=>*; rewrite -!catA perm_cat2l. Qed.
-
-Lemma perm_catCA s1 s2 s3 : perm (s1 ++ s2 ++ s3) (s2 ++ s1 ++ s3).
-Proof. by move=>*; rewrite !catA perm_cat2r. Qed.
 
 End Permutations.
 
-Hint Resolve perm_refl perm_catC perm_cons_catCA
-             perm_cons_catAC perm_catAC perm_catCA.
-
+Hint Resolve pperm_refl pperm_catC pperm_cons_catCA
+             pperm_cons_catAC pperm_catAC pperm_catCA : core.
 
 (* perm and map *)
-
-Lemma perm_map A B (f : A -> B) (s1 s2 : seq A) :
+Lemma pperm_map A B (f : A -> B) (s1 s2 : seq A) :
         perm s1 s2 -> perm (map f s1) (map f s2).
 Proof.
-set P := fun s1 s2 => perm (map f s1) (map f s2).
-suff {s1 s2} L: forall s1 s2, perm s1 s2 -> P s1 s2 by apply: L.
-apply: perm_ind2=>//; last 1 first.
-- move=>s2 s1 s3 _ IH1 _ IH2.
-  by apply: perm_trans IH1 IH2.
-- by move=>x s1 s2 H IH; rewrite /P perm_cons.
-move=>x1 x2 s1 s2 H IH.
-have L: perm [:: f x2, f x1 & map f s1] ([:: f x1] ++ [:: f x2 & map f s1]).
-- by apply/perm_cons_cat_cons.
-by apply: perm_trans L _; rewrite !perm_cons.
+elim=>[//|||??? _ IH1 _ IH2]*;
+by [apply/pperm_cons | apply/permutation_swap | apply/(pperm_trans IH1 IH2)].
 Qed.
 
 (* mapping to ssreflect decidable perm *)
-
 Lemma perm_eq_perm (A : eqType) (s1 s2 : seq A) :
         reflect (perm s1 s2) (perm_eq s1 s2).
 Proof.
 apply: (iffP idP); last first.
-- elim: s1 s2 /; last 1 first.
-  - by move=>s1 s2 t _ H2 _; apply: perm_eq_trans H2.
-  - by move=>s1 s2 ->->.
-  - by move=>s1 s2 x t1 t2 ->-> H1 H2; rewrite seq.perm_cons.
-  move=>s1 s2 x y t ->->.
-  by rewrite -(perm_rot 1) /rot /= seq.perm_cons seq.perm_catC.
-elim: s1 s2=>[|x s1 IH] /= s2.
-- move/perm_eq_mem=>H; apply/perm_nil.
-  by case: s2 H=>// a s2 /(_ a); rewrite inE eq_refl.
-move=>H; move: (perm_eq_mem H x); rewrite inE eq_refl; move/esym=>/= H'.
-move/(perm_eq_trans H): {H} (perm_to_rem H'); rewrite seq.perm_cons.
-move/IH/(perm_cons x)=>H; apply: perm_trans H _.
-elim: s2 x H'=>[|y s2 IH2] //= x.
-rewrite inE; case/orP; first by move/eqP=><-; rewrite eq_refl.
-case: eqP=>[->//|_ H]; move/(perm_cons y): (IH2 _ H).
-by apply: perm_trans; apply: permutation_swap.
+- elim=>[|||??? _ H1 _ H2]*.
+  - by apply seq.perm_refl.
+  - by rewrite seq.perm_cons.
+  - by rewrite -![[:: _, _ & _]]/([::_] ++ [::_] ++ _) seq.perm_catCA;
+       rewrite !seq.perm_cat2l.
+  by apply: seq.perm_trans H1 H2.
+elim: s2 s1 =>[s1 /seq.perm_size/size0nil->// | x s2 IH s1 H].
+move: (seq.perm_mem H x); rewrite mem_head=>H'; move: H' H.
+move/splitPr=>[p1 p2]; rewrite -cat1s seq.perm_catCA seq.perm_cons=>/IH.
+by rewrite -[_::s2]cat0s pperm_cat_cons.
 Qed.
-

--- a/Core/pred.v
+++ b/Core/pred.v
@@ -2,21 +2,22 @@ Require Import ssreflect ssrbool ssrfun.
 Require Import Setoid Morphisms.
 From mathcomp Require Import eqtype seq.
 Set Implicit Arguments.
-Unset Strict Implicit. 
-Unset Printing Implicit Defensive. 
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
 
 (* First some basic propositional equalities Basically, we need to repeat *)
 (* most of ssrbool.v here but we'll do it as we go. *)
 
 Lemma andTp p : True /\ p <-> p.      Proof. by intuition. Qed.
-Lemma andpT p : p /\ True <-> p.      Proof. by intuition. Qed.  
+Lemma andpT p : p /\ True <-> p.      Proof. by intuition. Qed.
 Lemma andFp p : False /\ p <-> False. Proof. by intuition. Qed.
 Lemma andpF p : p /\ False <-> False. Proof. by intuition. Qed.
 Lemma orTp p : True \/ p <-> True.    Proof. by intuition. Qed.
-Lemma orpT p : p \/ True <-> True.    Proof. by intuition. Qed.  
+Lemma orpT p : p \/ True <-> True.    Proof. by intuition. Qed.
 Lemma orFp p : False \/ p <-> p.      Proof. by intuition. Qed.
 Lemma orpF p : p \/ False <-> p.      Proof. by intuition. Qed.
 
+Declare Scope rel_scope.
 Delimit Scope rel_scope with rel.
 Open Scope rel_scope.
 
@@ -26,7 +27,7 @@ Open Scope rel_scope.
 (* (1) Pred is the type of propositional functions                        *)
 (* (2) Simpl_Pred is the type of predicates that automatically simplify   *)
 (*     when used in an applicative position.                              *)
-(* (3) Mem_Pred is for predicates that support infix notation x \In P     *) 
+(* (3) Mem_Pred is for predicates that support infix notation x \In P     *)
 (* (4) PredType is the structure for interpreting various types, such as  *)
 (* lists, tuples, etc. as predicates.                                     *)
 (*                                                                        *)
@@ -78,8 +79,8 @@ Definition isMem pT toPred mem := mem = (fun p : pT => MemProp [eta toPred p]).
 (* the general structure for predicates *)
 
 Structure PredType : Type := PropPredType {
-  Pred_Sort :> Type; 
-  toPred : Pred_Sort -> Pred T; 
+  Pred_Sort :> Type;
+  toPred : Pred_Sort -> Pred T;
   _ : {mem | isMem toPred mem}}.
 
 Definition mkPredType pT toP := PropPredType (exist (@isMem pT toP) _ (erefl _)).
@@ -91,18 +92,18 @@ Coercion Pred_of_Mem mp : Pred_Sort PredPredType :=
   let: MemProp p := mp in [eta p].
 Canonical Structure MemPredType := Eval hnf in mkPredType Pred_of_Mem.
 Canonical Structure predPredType := Eval hnf in @mkPredType (pred T) id.
-Canonical Structure simplpredPredType := 
+Canonical Structure simplpredPredType :=
   Eval hnf in @mkPredType (simpl_pred T) (fun p x => p x).
 
 End Predicates.
 
-Arguments Pred0 [T].
-Arguments PredT [T].
+Arguments Pred0 {T}.
+Arguments PredT {T}.
 Prenex Implicits Pred0 PredT PredI PredU PredC PredD Preim.
 
-Notation "r1 +p r2" := (PredU r1 r2 : Pred _) 
+Notation "r1 +p r2" := (PredU r1 r2 : Pred _)
   (at level 55, right associativity) : rel_scope.
-Notation "r1 *p r2" := (xPredI r1 r2 : Pred _) 
+Notation "r1 *p r2" := (xPredI r1 r2 : Pred _)
   (at level 45, right associativity) : rel_scope.
 
 Notation "[ 'Pred' : T | E ]" := (SimplPred (fun _ : T => E))
@@ -113,7 +114,7 @@ Notation "[ 'Pred' x : T | E ]" := (SimplPred (fun x : T => E))
   (at level 0, x ident, only parsing) : fun_scope.
 Notation "[ 'Pred' x y | E ]" := (SimplPred (fun t => let: (x, y) := t in E))
   (at level 0, x ident, y ident, format "[ 'Pred'  x  y  |  E ]") : fun_scope.
-Notation "[ 'Pred' x y : T | E ]" := 
+Notation "[ 'Pred' x y : T | E ]" :=
   (SimplPred (fun t : (T*T) => let: (x, y) := t in E))
   (at level 0, x ident, y ident, only parsing) : fun_scope.
 
@@ -146,10 +147,10 @@ Coercion Pred_of_Mem_Pred T mp := [Pred x : T | InMem x mp].
 
 (* equality and subset *)
 
-Definition EqPredType T (pT : PredType T) (p1 p2 : pT) := 
+Definition EqPredType T (pT : PredType T) (p1 p2 : pT) :=
   forall x : T, toPred p1 x <-> toPred p2 x.
 
-Definition SubPredType T (pT : PredType T) (p1 p2 : pT) := 
+Definition SubPredType T (pT : PredType T) (p1 p2 : pT) :=
   forall x : T, toPred p1 x -> toPred p2 x.
 
 (* Definition EqPred T (p1 p2 : Pred T) := EqPredType p1 p2. *)
@@ -157,34 +158,34 @@ Definition SubPredType T (pT : PredType T) (p1 p2 : pT) :=
 Definition EqSimplPred T (p1 p2 : Simpl_Pred T) := EqPredType p1 p2.
 Definition SubSimplPred T (p1 p2 : Simpl_Pred T) := SubPredType p1 p2.
 (*
-Definition EqMem T (p1 p2 : Mem_Pred T) := EqPredType p1 p2. 
+Definition EqMem T (p1 p2 : Mem_Pred T) := EqPredType p1 p2.
 Definition SubMem T (p1 p2 : Mem_Pred T) := SubPredType p1 p2.
 *)
 
-Definition EqPredFun T1 T2 (pT2 : PredType T2) p1 p2 := 
+Definition EqPredFun T1 T2 (pT2 : PredType T2) p1 p2 :=
   forall x : T1, @EqPredType T2 pT2 (p1 x) (p2 x).
-Definition SubPredFun T1 T2 (pT2 : PredType T2) p1 p2 := 
+Definition SubPredFun T1 T2 (pT2 : PredType T2) p1 p2 :=
   forall x : T1, @SubPredType T2 pT2 (p1 x) (p2 x).
 
 Definition EqMem T p1 p2 := forall x : T, InMem x p1 <-> InMem x p2.
 Definition SubMem T p1 p2 := forall x : T, InMem x p1 -> InMem x p2.
 
-Notation "A <~> B" := (@EqPredType _ _ A B) 
+Notation "A <~> B" := (@EqPredType _ _ A B)
   (at level 70, no associativity) : rel_scope.
-Notation "A ~> B" := (@SubPredType _ _ A B) 
+Notation "A ~> B" := (@SubPredType _ _ A B)
   (at level 70, no associativity) : rel_scope.
-Notation "A <~1> B" := (@EqPredFun _ _ _ A B) 
+Notation "A <~1> B" := (@EqPredFun _ _ _ A B)
   (at level 70, no associativity) : rel_scope.
-Notation "A ~1> B" := (@SubPredFun _ _ _ A B) 
+Notation "A ~1> B" := (@SubPredFun _ _ _ A B)
   (at level 70, no associativity) : rel_scope.
 
-Notation "x \In A" := (InMem x (Mem A)) 
+Notation "x \In A" := (InMem x (Mem A))
   (at level 70, no associativity) : rel_scope.
-Notation "x \Notin A" := (~ (x \In A)) 
+Notation "x \Notin A" := (~ (x \In A))
   (at level 70, no associativity) : rel_scope.
-Notation "A =p B" := (EqMem (Mem A) (Mem B)) 
+Notation "A =p B" := (EqMem (Mem A) (Mem B))
   (at level 70, no associativity) : type_scope.
-Notation "A <=p B" := (SubMem (Mem A) (Mem B))  
+Notation "A <=p B" := (SubMem (Mem A) (Mem B))
   (at level 70, no associativity) : type_scope.
 
 (* Some notation for turning PredTypes into Pred or Simple Pred *)
@@ -219,7 +220,7 @@ Notation "[ 'Pred' x y \In A ]" := [Pred x y \In A & A]
   (at level 0, x ident, y ident,
    format "[ 'Pred'  x  y  \In  A ]") : fun_scope.
 
-Section Simplifications. 
+Section Simplifications.
 Variables (T : Type) (pT : PredType T).
 
 Lemma Mem_toPred : forall (p : pT), Mem (toPred p) = Mem p.
@@ -244,7 +245,7 @@ Definition MemE := Mem_Simpl. (* could be extended *)
 Lemma Mem_Mem : forall p : pT, (Mem (Mem p) = Mem p) * (Mem [Mem p] = Mem p).
 Proof. by move=> p; rewrite -Mem_toPred. Qed.
 
-End Simplifications. 
+End Simplifications.
 
 (**************************************)
 (* Definitions and lemmas for setoids *)
@@ -254,24 +255,24 @@ Section RelProperties.
 Variables (T : Type) (pT : PredType T).
 
 Lemma EqPredType_refl (r : pT) : EqPredType r r. Proof. by []. Qed.
-Lemma SubPredType_refl (r : pT) : SubPredType r r. Proof. by []. Qed.  
+Lemma SubPredType_refl (r : pT) : SubPredType r r. Proof. by []. Qed.
 
 Lemma EqPredType_sym (r1 r2 : pT) : EqPredType r1 r2 -> EqPredType r2 r1.
 Proof. by move=>H1 x; split; move/H1. Qed.
 
-Lemma EqPredType_trans' (r1 r2 r3 : pT) : 
+Lemma EqPredType_trans' (r1 r2 r3 : pT) :
   EqPredType r1 r2 -> EqPredType r2 r3 -> EqPredType r1 r3.
 Proof. by move=>H1 H2 x; split; [move/H1; move/H2 | move/H2; move/H1]. Qed.
- 
-Lemma SubPredType_trans' (r1 r2 r3 : pT) : 
-  SubPredType r1 r2 -> SubPredType r2 r3 -> SubPredType r1 r3.
-Proof. by move=>H1 H2 x; move/H1; move/H2. Qed. 
 
-Definition EqPredType_trans r2 r1 r3 := @EqPredType_trans' r1 r2 r3. 
+Lemma SubPredType_trans' (r1 r2 r3 : pT) :
+  SubPredType r1 r2 -> SubPredType r2 r3 -> SubPredType r1 r3.
+Proof. by move=>H1 H2 x; move/H1; move/H2. Qed.
+
+Definition EqPredType_trans r2 r1 r3 := @EqPredType_trans' r1 r2 r3.
 Definition SubPredType_trans r2 r1 r3 := @SubPredType_trans' r1 r2 r3.
 End RelProperties.
 
-Hint Resolve EqPredType_refl SubPredType_refl.
+Hint Resolve EqPredType_refl SubPredType_refl : core.
 
 (* Declaration of relations *)
 
@@ -280,10 +281,10 @@ Hint Resolve EqPredType_refl SubPredType_refl.
 (* for all instances. This is really annoying, but at least I don't have  *)
 (* to reprove the lemmas on refl, sym and trans                           *)
 (*                                                                        *)
-Add Parametric Relation T (pT : PredType T) : pT (@EqPredType _ pT)    
-   reflexivity proved by (@EqPredType_refl _ _)                         
-  symmetry proved by (@EqPredType_sym _ _)                              
-  transitivity proved by (@EqPredType_trans' _ _) as EqPredType_rel.    
+Add Parametric Relation T (pT : PredType T) : pT (@EqPredType _ pT)
+   reflexivity proved by (@EqPredType_refl _ _)
+  symmetry proved by (@EqPredType_sym _ _)
+  transitivity proved by (@EqPredType_trans' _ _) as EqPredType_rel.
 
 (*                                                                        *)
 (* Add Parametric Relation T (pT : PredType T) : pT (@SubPredType _ pT)   *)
@@ -295,7 +296,7 @@ Add Parametric Relation T (pT : PredType T) : pT (@EqPredType _ pT)
   symmetry proved by (@EqPredType_sym _ _)
   transitivity proved by (@EqPredType_trans' _ _) as EqPred_rel.
 
-Add Parametric Relation T : (Pred T) (@SubPred _) 
+Add Parametric Relation T : (Pred T) (@SubPred _)
   reflexivity proved by (@SubPredType_refl _ _)
   transitivity proved by (@SubPredType_trans' _ _) as SubPred_rel.
 *)
@@ -305,7 +306,7 @@ Add Parametric Relation T : (Simpl_Pred T) (@EqSimplPred _)
   symmetry proved by (@EqPredType_sym _ _)
   transitivity proved by (@EqPredType_trans' _ _) as EqSimplPred_rel.
 
-Add Parametric Relation T : (Simpl_Pred T) (@SubSimplPred _) 
+Add Parametric Relation T : (Simpl_Pred T) (@SubSimplPred _)
   reflexivity proved by (@SubPredType_refl _ _)
   transitivity proved by (@SubPredType_trans' _ _) as SubSimplPred_rel.
 
@@ -314,7 +315,7 @@ Add Parametric Relation T : (Mem_Pred T) (@EqMem T)
   symmetry proved by (@EqPredType_sym _ _)
   transitivity proved by (@EqPredType_trans' _ _) as EqMem_rel.
 
-Add Parametric Relation T : (Mem_Pred T) (@SubMem _) 
+Add Parametric Relation T : (Mem_Pred T) (@SubMem _)
   reflexivity proved by (@SubPredType_refl _ _)
   transitivity proved by (@SubPredType_trans' _ _) as SubMem_rel.
 
@@ -322,7 +323,7 @@ Add Parametric Relation T : (Mem_Pred T) (@SubMem _)
 (* Annoyingly, even the coercions must be declared *)
 
 Add Parametric Morphism T : (@Pred_of_Simpl T) with signature
-      @EqSimplPred _ ==> @EqPredType T (PredPredType T) as Pred_of_Simpl_morph. 
+      @EqSimplPred _ ==> @EqPredType T (PredPredType T) as Pred_of_Simpl_morph.
 Proof. by []. Qed.
 
 (* Do we need other coercions? We'll discover as we go *)
@@ -334,20 +335,20 @@ Proof. by []. Qed.
 (* even though the former is an instance of the later.                *)
 
 (*
-Add Parametric Morphism T : (@EqPred T) with signature 
+Add Parametric Morphism T : (@EqPred T) with signature
     @EqPred _ ==> @EqPred _ ==> iff as EqPred_morph.
 Proof. by move=>r1 s1 H1 r2 s2 H2; rewrite H1 H2. Qed.
 *)
 
-Add Parametric Morphism T (pT : PredType T) : (@EqPredType T pT) with signature 
+Add Parametric Morphism T (pT : PredType T) : (@EqPredType T pT) with signature
     @EqPredType _ _ ==> @EqPredType _ _ ==> iff as EqPredType_morph.
 Proof. by move=>r1 s1 H1 r2 s2 H2; rewrite H1 H2. Qed.
 
-Add Parametric Morphism T (pT : PredType T) : (@SubPredType T pT) with signature 
+Add Parametric Morphism T (pT : PredType T) : (@SubPredType T pT) with signature
     @EqPredType _ _ ==> @EqPredType _ _ ==> iff as SubPred_morph.
 Proof. by move=>r1 s1 H1 r2 s2 H2; split=>H x; move/H1; move/H; move/H2. Qed.
 
-Add Parametric Morphism T : (@InMem T) with signature 
+Add Parametric Morphism T : (@InMem T) with signature
     @eq _ ==> @EqMem _ ==> iff as InMem_morph.
 Proof. by move=>x r s H; split; move/H. Qed.
 
@@ -355,21 +356,21 @@ Add Parametric Morphism T (pT : PredType T) : (@Mem T pT) with signature
   @EqPredType _ _ ==> @EqMem _ as Mem_morhp.
 Proof. by move=>x y H p; rewrite /EqPredType -!toPredE in H *; rewrite H. Qed.
 
-Add Parametric Morphism T : (@PredU T) with signature 
+Add Parametric Morphism T : (@PredU T) with signature
     @EqPredType _ _ ==> @EqPredType _ _ ==> @EqSimplPred _ as predU_morph.
 Proof.
-move=>r1 s1 H1 r2 h2 H2 x; split; 
+move=>r1 s1 H1 r2 h2 H2 x; split;
 by case; [move/H1 | move/H2]=>/=; auto.
 Qed.
 
-Add Parametric Morphism T : (@PredI T) with signature 
+Add Parametric Morphism T : (@PredI T) with signature
     @EqPredType _ _ ==> @EqPredType _ _ ==> @EqPredType _ _ as predI_morph.
 Proof.
-move=>r1 s1 H1 r2 s2 H2 x; split; 
+move=>r1 s1 H1 r2 s2 H2 x; split;
 by case; move/H1=>T1; move/H2=>T2.
 Qed.
 
-Add Parametric Morphism T : (@PredC T) with signature 
+Add Parametric Morphism T : (@PredC T) with signature
     @EqPredType _ _ ==> @EqPredType _ _ as predC_morph.
 Proof. by move=>r s H x; split=>H1; apply/H. Qed.
 
@@ -380,7 +381,7 @@ Lemma orrI (r : Pred nat) : r +p r <~> r.
 Proof.  by move=>x; split; [case | left]. Qed.
 
 Lemma orrC (r1 r2 : Pred T) : r1 +p r2 <~> r2 +p r1.
-Proof. move=>x; split=>/=; tauto. Qed. 
+Proof. move=>x; split=>/=; tauto. Qed.
 
 Lemma orr0 (r : Pred T) : r +p Pred0 <~> r.
 Proof. by move=>x; split; [case | left]. Qed.
@@ -398,7 +399,7 @@ Lemma orrA (r1 r2 r3 : Pred T) : (r1 +p r2) +p r3 <~> r1 +p r2 +p r3.
 Proof. by rewrite (orrC r2) orrCA orrC. Qed.
 
 (* absorption *)
-Lemma orrAb (r1 a : Pred T) : r1 <~> r1 +p a <-> a ~> r1. 
+Lemma orrAb (r1 a : Pred T) : r1 <~> r1 +p a <-> a ~> r1.
 Proof.
 split; first by move=>-> x /=; auto.
 move=>H x /=; split; first by auto.
@@ -406,7 +407,7 @@ by case=>//; move/H.
 Qed.
 
 Lemma sub_orl (r1 r2 : Pred T) : r1 ~> r1 +p r2. Proof. by left. Qed.
-Lemma sub_orr (r1 r2 : Pred T) : r2 ~> r1 +p r2. Proof. by right. Qed.   
+Lemma sub_orr (r1 r2 : Pred T) : r2 ~> r1 +p r2. Proof. by right. Qed.
 
 End RelLaws.
 
@@ -423,7 +424,7 @@ Lemma subp_trans (p2 p1 p3 : Pred T) : p1 <=p p2 -> p2 <=p p3 -> p1 <=p p3.
 Proof. by move=>H1 H2 x; move/H1; move/H2. Qed.
 
 Lemma subp_or (p1 p2 q : Pred T) : p1 <=p q /\ p2 <=p q <-> p1 +p p2 <=p q.
-Proof. 
+Proof.
 split=>[[H1] H2 x|H1]; first by case; [move/H1 | move/H2].
 by split=>x H2; apply: H1; [left | right].
 Qed.
@@ -448,7 +449,7 @@ Proof. by move=>H x [H1 H2]; split; [|apply: H]. Qed.
 
 End SubMemLaws.
 
-Hint Resolve subp_refl.
+Hint Resolve subp_refl : core.
 
 Section ListMembership.
 Variable T : Type.
@@ -462,7 +463,7 @@ Identity Coercion seq_of_EqSeq : EqSeq_Class >-> seq.
 Coercion Pred_of_Eq_Seq (s : EqSeq_Class) : Pred_Class := [eta Mem_Seq s].
 
 Canonical Structure seq_PredType := @mkPredType T (seq T) Pred_of_Eq_Seq.
-(* The line below makes Mem_Seq a canonical instance of topred. *) 
+(* The line below makes Mem_Seq a canonical instance of topred. *)
 Canonical Structure Mem_Seq_PredType := mkPredType Mem_Seq.
 
 Lemma In_cons : forall y s x, (x \In y :: s) <-> (x = y) \/ (x \In s).
@@ -484,27 +485,34 @@ Proof.
 move=>x; elim=>[|y s1 IH] s2 /=; first by split; [right | case].
 rewrite !InE /=.
 split.
-- case=>[->|/IH]; first by left; left. 
-  by case; [left; right | right]. 
-case; first by case; [left | move=>H; right; apply/IH; left]. 
-by move=>H; right; apply/IH; right. 
+- case=>[->|/IH]; first by left; left.
+  by case; [left; right | right].
+case; first by case; [left | move=>H; right; apply/IH; left].
+by move=>H; right; apply/IH; right.
+Qed.
+
+Lemma In_split x s : x \In s -> exists s1 s2, s = s1 ++ x :: s2.
+Proof.
+elim:s=>[|y s IH] //=; rewrite InE.
+case=>[<-|]; first by exists [::], s.
+by case/IH=>s1 [s2 ->]; exists (y :: s1), s2.
 Qed.
 
 End ListMembership.
 
-Lemma Mem_map T T' (f : T -> T') x (s : seq T) : 
+Lemma Mem_map T T' (f : T -> T') x (s : seq T) :
          x \In s -> f x \In (map f s).
 Proof.
 elim: s=>[|y s IH] //; rewrite InE /=.
 by case=>[<-|/IH]; [left | right].
 Qed.
 
-Lemma Mem_map_inv T T' (f : T -> T') x (s : seq T) : 
+Lemma Mem_map_inv T T' (f : T -> T') x (s : seq T) :
         x \In (map f s) -> exists y, x = f y /\ y \In s.
 Proof.
 elim: s=>[|y s IH] //=; rewrite InE /=.
-case; first by move=>->; exists y; split=>//; left. 
-by case/IH=>z [->]; exists z; split=>//; right. 
+case; first by move=>->; exists y; split=>//; left.
+by case/IH=>z [->]; exists z; split=>//; right.
 Qed.
 
 Prenex Implicits Mem_map_inv.
@@ -512,7 +520,7 @@ Prenex Implicits Mem_map_inv.
 (* Setoids for extensional equality of functions *)
 
 Lemma eqfun_refl A B (f : A -> B) : f =1 f. Proof. by []. Qed.
-Lemma eqfun_sym A B (f1 f2 : A -> B) : f1 =1 f2 -> f2 =1 f1. 
+Lemma eqfun_sym A B (f1 f2 : A -> B) : f1 =1 f2 -> f2 =1 f1.
 Proof. by move=>H x; rewrite H. Qed.
 Lemma eqfun_trans A B (f1 f2 f3 : A -> B) : f1 =1 f2 -> f2 =1 f3 -> f1 =1 f3.
 Proof. by move=>H1 H2 x; rewrite H1 H2. Qed.
@@ -534,7 +542,7 @@ Inductive image_spec b : Prop := Im_mem a of b = f a & a \In P.
 
 Definition Image' := [Pred b | image_spec b].
 
-End Image. 
+End Image.
 
 (* swap to make the notation consider P before E; helps inference *)
 Notation Image f P := (Image' P f).
@@ -557,24 +565,24 @@ Notation "[ 'Image' E | i : T <- s & C ]" :=
 Lemma Image_mem A B (f : A -> B) (P : Pred A) x : x \In P -> f x \In Image f P.
 Proof. by apply: Im_mem. Qed.
 
-Lemma Image_inj_sub A B (f : A -> B) (X1 X2 : Pred A) : 
+Lemma Image_inj_sub A B (f : A -> B) (X1 X2 : Pred A) :
         injective f -> Image f X1 <=p Image f X2 -> X1 <=p X2.
 Proof. by move=>H E x /(Image_mem f) /E [y] /H ->. Qed.
 
-Lemma Image_inj_eqmem A B (f : A -> B) (X1 X2 : Pred A) : 
+Lemma Image_inj_eqmem A B (f : A -> B) (X1 X2 : Pred A) :
         injective f -> Image f X1 =p Image f X2 -> X1 =p X2.
 Proof. by move=>H E; split; apply: Image_inj_sub H _ _; rewrite E. Qed.
 
-Lemma ImageU A B (f : A -> B) (X1 X2 : Pred A) : 
+Lemma ImageU A B (f : A -> B) (X1 X2 : Pred A) :
         Image f (PredU X1 X2) =p [PredU Image f X1 & Image f X2].
 Proof.
 move=>x; split.
-- by case=>y -> [H|H]; [left | right]; apply: Image_mem. 
-by case; case=>y -> H; apply: Image_mem; [left | right]. 
+- by case=>y -> [H|H]; [left | right]; apply: Image_mem.
+by case; case=>y -> H; apply: Image_mem; [left | right].
 Qed.
 
-Lemma ImageIm A B C (f1 : B -> C) (f2 : A -> B) (X : Pred A) : 
-        Image f1 (Image f2 X) =p Image (f1 \o f2) X. 
+Lemma ImageIm A B C (f1 : B -> C) (f2 : A -> B) (X : Pred A) :
+        Image f1 (Image f2 X) =p Image (f1 \o f2) X.
 Proof.
 move=>x; split; first by case=>_ -> [x' ->] H; exists x'.
 by case=>a -> H; exists (f2 a)=>//; exists a.

--- a/Core/prelude.v
+++ b/Core/prelude.v
@@ -1,4 +1,4 @@
-Require Import ssreflect ssrbool ssrfun. 
+Require Import ssreflect ssrbool ssrfun.
 Require Import Eqdep ClassicalFacts.
 From mathcomp Require Import ssrnat eqtype seq.
 From HTT Require Import pred.
@@ -61,7 +61,7 @@ Proof. by []. Qed.
 
 (* inferrable reflexivity axiom *)
 Definition erefli A (x : A) := erefl x.
-Arguments erefli [A x].
+Arguments erefli {A x}.
 
 (* selecting a list element *)
 (* should really be in seq.v *)
@@ -158,7 +158,7 @@ Qed.
 
 End ReflectConnectives.
 
-Arguments and6P [b1 b2 b3 b4 b5 b6].
-Arguments or5P [b1 b2 b3 b4 b5].
-Arguments or6P [b1 b2 b3 b4 b5 b6].
+Arguments and6P {b1 b2 b3 b4 b5 b6}.
+Arguments or5P {b1 b2 b3 b4 b5}.
+Arguments or6P {b1 b2 b3 b4 b5 b6}.
 Prenex Implicits and6P or5P or6P.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ of) Hoare logic, corresponds to a command in HTT which has that rule as the type
 
 ### Requirements
 
-* [Coq](https://coq.inria.fr/download) (>= "8.9.0" & < "8.12~")
-* [Mathematical Components](http://math-comp.github.io/math-comp/) `ssreflect` (>= "1.10.0" & < "1.11~")
+* [Coq](https://coq.inria.fr/download) (>= "8.10.0" & < "8.12~")
+* [Mathematical Components](http://math-comp.github.io/math-comp/) `ssreflect` (>= "1.10.0" & < "1.12~")
 * [FCSL-PCM](https://github.com/imdea-software/fcsl-pcm) (>= "1.0.0" & < "1.3~")
 
 For the installation, follow instructions in the corresponding

--- a/coq-htt.opam
+++ b/coq-htt.opam
@@ -21,8 +21,8 @@ build: [ make ]
 install: [ make "install" ]
 depends: [
   "ocaml"
-  "coq" {(>= "8.9.0" & < "8.12~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.10.0" & < "1.11~") | (= "dev")}
+  "coq" {(>= "8.10.0" & < "8.12~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.10.0" & < "1.12~") | (= "dev")}
   "coq-fcsl-pcm" {(>= "1.0.0" & < "1.3~") | (= "dev")}
 ]
 tags: [


### PR DESCRIPTION
* `perm_eq_trans` and `perm_eq_mem` no longer exist in 1.11, and lemmas name clash, plus overall style seemed less effective than its FCSL counterpart, so I've just used the FCSL version.
* fixed warnings for implicit arguments and hints database
* I'm not sure if the new version compiles with Coq 8.9, so I bumped the minimal requirement to 8.10, does this sound reasonable?